### PR TITLE
Fix bug when use `Basic` type

### DIFF
--- a/src/PHPRedisServiceProvider.php
+++ b/src/PHPRedisServiceProvider.php
@@ -20,7 +20,7 @@ class PHPRedisServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('phpredis', function ($app) {
+        $this->app->singleton('redis', function ($app) {
             $app->configure('database');
             return new Database($app->config['database.redis']);
         });


### PR DESCRIPTION
修复一个bug。PHPRedisServiceProvider中，若使用singleton('phpredis', xxxx)时无法正常使用。可能是需要额外配置，但没找到。此处修改成redis后可以直接使用。
